### PR TITLE
feat: add multicoin support

### DIFF
--- a/src/abi.ts
+++ b/src/abi.ts
@@ -89,5 +89,31 @@ export const ABI = [
     ],
     stateMutability: 'view',
     type: 'function'
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'node',
+        type: 'bytes32'
+      },
+      {
+        internalType: 'uint256',
+        name: 'coinType',
+        type: 'uint256'
+      }
+    ],
+    name: 'addr',
+    outputs: [
+      {
+        internalType: 'bytes',
+        name: '',
+        type: 'bytes'
+      }
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
   }
-]
+];

--- a/tests/getENS.test.ts
+++ b/tests/getENS.test.ts
@@ -25,7 +25,14 @@ t('resolves the address and text records', async () => {
       github: 'talentlessguy',
       reddit: 'v1rtl'
     },
-    domain: 'v1rtl.eth'
+    domain: 'v1rtl.eth',
+    coinTypes: {
+      '0': '0xa9140575e888bbb4dc7fa0c344a20b07e99516ee9c0d87',
+      '128': '0x124306de2e02868589c0709894b6c71daea74ed66b6007b17cbc08735a615703693b6b5d64bdc33e7f3920873b93d256116f5c4f8d47cf5adfd718a7a43f43c9495cdf6b7d',
+      '2': '0xa914922122dc91b59071af4725d9d8dbcff796657f6d87',
+      '3': '0x76a914b484c576c107ca6a614ce0dd024d1021f7ee4abe88ac',
+      '60': '0xd3b282e9880cdcb1142830731cd83f7ac0e1043f'
+    },
   })
 })
 
@@ -34,7 +41,8 @@ t('resolves without address', async () => {
     address: null,
     owner: '0xe5501bc2b0df6d0d7daafc18d2ef127d9e612963',
     domain: 'lilnasx.eth',
-    records: {}
+    records: {},
+    coinTypes: {}
   })
 })
 
@@ -45,7 +53,8 @@ t('supports custom fetch options', async () => {
     address: null,
     owner: '0xe5501bc2b0df6d0d7daafc18d2ef127d9e612963',
     domain: 'lilnasx.eth',
-    records: {}
+    records: {},
+    coinTypes: {}
   })
 })
 
@@ -65,7 +74,14 @@ t('does a reverse lookup if ethereum address is passed', async () => {
       github: 'talentlessguy',
       reddit: 'v1rtl'
     },
-    domain: 'v1rtl.eth'
+    domain: 'v1rtl.eth',
+    coinTypes: {
+      '0': '0xa9140575e888bbb4dc7fa0c344a20b07e99516ee9c0d87',
+      '128': '0x124306de2e02868589c0709894b6c71daea74ed66b6007b17cbc08735a615703693b6b5d64bdc33e7f3920873b93d256116f5c4f8d47cf5adfd718a7a43f43c9495cdf6b7d',
+      '2': '0xa914922122dc91b59071af4725d9d8dbcff796657f6d87',
+      '3': '0x76a914b484c576c107ca6a614ce0dd024d1021f7ee4abe88ac',
+      '60': '0xd3b282e9880cdcb1142830731cd83f7ac0e1043f'
+    },
   })
 })
 
@@ -76,7 +92,8 @@ t('returns "null" for a domain if ENS is not present', async () => {
     address: '0x604Ee422975E74050Eeaa3fC74BAbf6E008C0acC',
     owner: '0x604Ee422975E74050Eeaa3fC74BAbf6E008C0acC',
     domain: null,
-    records: {}
+    records: {},
+    coinTypes: {},
   })
 })
 


### PR DESCRIPTION
Adds support for fetching `coinTypes` from GraphQL and making the contract call to retrieve the value. I decided against adding https://github.com/ensdomains/address-encoder as a dep, but that could be an option if you want this library to also decode the hex value returned from the contract call. 

I'll follow up with naming and types after an initial review. 